### PR TITLE
Add a method to return multiple addresses

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -166,7 +166,7 @@ func TagServiceHostPortMulti(service, tag string) (hostPort []string, err error)
 	// Add service to map if it doesn't exist or update host port
 	serviceCacheMutex.RLock()
 	firstLookup := serviceCache[st] == nil
-	hostPortChanged := !firstLookup && serviceCache[st].SameHosts(hostPort)
+	hostPortChanged := !firstLookup && !serviceCache[st].SameHosts(hostPort)
 	serviceCacheMutex.RUnlock()
 
 	if firstLookup {

--- a/consul_test.go
+++ b/consul_test.go
@@ -104,4 +104,26 @@ func TestTagServiceHostPort(t *testing.T) {
 		assert.NoError(t, err, "there should not be an error as there was a recent successful lookup")
 		assert.Equal(t, "serviceAddress2:80", hostPort, "service address should be used with service port")
 	})
+
+	t.Run("multi host port", func(t *testing.T) {
+		cservices := []*api.CatalogService{
+			&api.CatalogService{
+				ServiceAddress: "serviceAddress1",
+				ServicePort:    80,
+			},
+			&api.CatalogService{
+				ServiceAddress: "serviceAddress2",
+				ServicePort:    80,
+			},
+		}
+		expectedHostPorts := []string{
+			"serviceAddress1:80",
+			"serviceAddress2:80",
+		}
+		mCatalog.EXPECT().Service("service10", "", nil).Return(cservices, nil, nil).Times(1)
+
+		hostPorts, err := TagServiceHostPortMulti("service10", "")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedHostPorts, hostPorts)
+	})
 }


### PR DESCRIPTION
This adds a new method called `TagServiceHostPortMulti` which works just like `TagServiceHostPort` but returns an array of addresses.

Raises the coverage to 74.7%.